### PR TITLE
(docs) Nest private key directly under key-data

### DIFF
--- a/ssh_basic_inventory.yaml
+++ b/ssh_basic_inventory.yaml
@@ -19,8 +19,9 @@ config:
       _plugin: puppet_connect_data
       key: ssh_target_user
     private-key:
-      _plugin: puppet_connect_data
-      key: ssh_target_private_key
+      key-data:
+        _plugin: puppet_connect_data
+        key: ssh_target_private_key
 targets:
   - name: ssh_target_1
     uri: ssh_target_1.example.com # This URI needs to be replaced with a real target


### PR DESCRIPTION
Without this the key is interpreted as a path, not the key data.